### PR TITLE
Bugfix/includes index

### DIFF
--- a/src/Incraigulous/Contentful/EntriesRepositoryBase.php
+++ b/src/Incraigulous/Contentful/EntriesRepositoryBase.php
@@ -203,6 +203,7 @@ abstract class EntriesRepositoryBase {
      * @return Model
      */
     protected function getModelFromList($result) {
+    		$includes = isset( $result['includes'] ) ? $includes : array();
         return ModelFactory::make($result['items'][0], $result['includes'], $this->id);
     }
 }

--- a/src/Incraigulous/Contentful/EntriesRepositoryBase.php
+++ b/src/Incraigulous/Contentful/EntriesRepositoryBase.php
@@ -204,6 +204,6 @@ abstract class EntriesRepositoryBase {
      */
     protected function getModelFromList($result) {
         $includes = isset( $result['includes'] ) ? $includes : array();
-        return ModelFactory::make($result['items'][0], $result['includes'], $this->id);
+        return ModelFactory::make($result['items'][0], $includes, $this->id);
     }
 }

--- a/src/Incraigulous/Contentful/EntriesRepositoryBase.php
+++ b/src/Incraigulous/Contentful/EntriesRepositoryBase.php
@@ -203,7 +203,7 @@ abstract class EntriesRepositoryBase {
      * @return Model
      */
     protected function getModelFromList($result) {
-    		$includes = isset( $result['includes'] ) ? $includes : array();
+        $includes = isset( $result['includes'] ) ? $includes : array();
         return ModelFactory::make($result['items'][0], $result['includes'], $this->id);
     }
 }


### PR DESCRIPTION
Was getting an undefined index error when querying for 1 content type entry, without includes. Seems like the `includes` index is not included in the response, in that case.

I'm very new to Contentful and your library, so wasn't sure of the right place to handle response validation. 

In any case, hope this helps. :)
